### PR TITLE
fix: make property `Item.properties` back to `public` so that it can be serialized

### DIFF
--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/model/Item.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/model/Item.kt
@@ -13,7 +13,11 @@ data class Item(val id: Long, val type: String, val count: Long, val status: Str
 		properties = deserialize(json)
 	}
 
-	private var properties = mapOf<String, String>()
+	/**
+	 * The property needs to be serialized so don't make it `private`.
+	 */
+	@Suppress("MemberVisibilityCanBePrivate")
+	var properties = mapOf<String, String>()
 
 	companion object {
 		private val logger = LoggerFactory.getLogger(Item::class.java)


### PR DESCRIPTION
Fixes https://github.com/Attacktive/troubleshooter-editor-back-end/issues/86.