### PR TITLE
refactor: configure `@ConfigurationProperties` properly

### DIFF
--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/configuration/PropertiesConfiguration.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/configuration/PropertiesConfiguration.kt
@@ -4,11 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 
 @ConfigurationProperties(prefix = "app")
-@ConfigurationPropertiesScan
-class PropertiesConfiguration {
-	val cors: Cors = Cors()
-
-	class Cors {
-		val origins: List<String> = mutableListOf()
-	}
+@ConfigurationPropertiesScan(basePackages = ["com.github.attacktive.troubleshootereditor.configuration"])
+class PropertiesConfiguration(val cors: Cors = Cors()) {
+	class Cors(val origins: List<String> = mutableListOf())
 }


### PR DESCRIPTION
Qodana apparently dislikes the current configurations.

![image](https://github.com/Attacktive/troubleshooter-editor-back-end/assets/66462458/3f99b6f0-8d00-4196-9193-4cc475a8c5ae)
![image](https://github.com/Attacktive/troubleshooter-editor-back-end/assets/66462458/43d328f5-f271-40f1-9fff-0815c16fc79a)