### PR TITLE
refactor: change type of properties and local variables to more specific one

### DIFF
--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/domain/common/Properties.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/domain/common/Properties.kt
@@ -2,7 +2,7 @@ package com.github.attacktive.troubleshootereditor.domain.common
 
 import java.util.function.Predicate
 
-data class Properties(private val list: List<Property> = mutableListOf()) {
+data class Properties(private val list: MutableList<Property> = mutableListOf()) {
 	fun containsKey(key: String) = keys().contains(key)
 	fun containsKeyThat(predicate: Predicate<String>) = keys().any { predicate.test(it) }
 
@@ -37,7 +37,7 @@ data class Properties(private val list: List<Property> = mutableListOf()) {
 			that.withDiffType(DiffType.ADDED)
 		}
 
-		return Properties(withThese + withThose)
+		return Properties((withThese + withThose).toMutableList())
 	}
 
 	private fun keys() = list.map { it.key }.toSet()

--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/domain/company/Company.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/domain/company/Company.kt
@@ -40,17 +40,17 @@ data class Company(val id: Int, val name: String, val vill: Long): PropertiesAwa
 
 	data class DiffResult(val id: Int, val name: String?, val vill: Long?, override val properties: Properties): PropertiesDiffAware {
 		override fun generateStatements(connection: Connection): List<PreparedStatement> {
-			val statements: List<PreparedStatement> = mutableListOf()
+			val statements: MutableList<PreparedStatement> = mutableListOf()
 
 			if (name != null) {
-				statements.addLast(updateStatementForName(connection))
+				statements.add(updateStatementForName(connection))
 			}
 
 			if (vill != null) {
-				statements.addLast(updateStatementForVill(connection))
+				statements.add(updateStatementForVill(connection))
 			}
 
-			getStatementsForProperties(connection).forEach { statements.addLast(it) }
+			getStatementsForProperties(connection).forEach { statements.add(it) }
 
 			return statements
 		}

--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/domain/item/Item.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/domain/item/Item.kt
@@ -22,7 +22,7 @@ data class Item(val id: Long, val type: String, val count: Long, val status: Str
 
 	companion object {
 		fun fromResultSet(resultSet: ResultSet): List<Item> {
-			val items: List<Item> = mutableListOf()
+			val items: MutableList<Item> = mutableListOf()
 
 			while (resultSet.next()) {
 				val id = resultSet.getLong("itemID")
@@ -42,7 +42,7 @@ data class Item(val id: Long, val type: String, val count: Long, val status: Str
 					}
 				}
 
-				items.addLast(Item(id, type, count, status, properties, equipmentPosition))
+				items.add(Item(id, type, count, status, properties, equipmentPosition))
 			}
 
 			return items
@@ -68,21 +68,21 @@ data class Item(val id: Long, val type: String, val count: Long, val status: Str
 
 	data class DiffResult(val id: Long, val type: String?, val count: Long?, val status: String?, override val properties: Properties): PropertiesDiffAware {
 		override fun generateStatements(connection: Connection): List<PreparedStatement> {
-			val statements: List<PreparedStatement> = mutableListOf()
+			val statements: MutableList<PreparedStatement> = mutableListOf()
 
 			if (type != null) {
-				statements.addLast(updateStatementForType(connection))
+				statements.add(updateStatementForType(connection))
 			}
 
 			if (count != null) {
-				statements.addLast(updateStatementForCount(connection))
+				statements.add(updateStatementForCount(connection))
 			}
 
 			if (status != null) {
-				statements.addLast(updateStatementForStatus(connection))
+				statements.add(updateStatementForStatus(connection))
 			}
 
-			getStatementsForProperties(connection).forEach { statements.addLast(it) }
+			getStatementsForProperties(connection).forEach { statements.add(it) }
 
 			return statements
 		}

--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/domain/roster/Roster.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/domain/roster/Roster.kt
@@ -20,7 +20,7 @@ data class Roster(val id: Long, val name: String, val `class`: String, val level
 
 	companion object {
 		fun fromResultSet(resultSet: ResultSet): List<Roster> {
-			val rosters: List<Roster> = mutableListOf()
+			val rosters: MutableList<Roster> = mutableListOf()
 
 			while (resultSet.next()) {
 				val id = resultSet.getLong("rosterID")
@@ -30,7 +30,7 @@ data class Roster(val id: Long, val name: String, val `class`: String, val level
 				val exp = resultSet.getLong("rosterExp")
 				val properties = resultSet.getString("properties")
 
-				rosters.addLast(Roster(id, name, `class`, level, exp, properties))
+				rosters.add(Roster(id, name, `class`, level, exp, properties))
 			}
 
 			return rosters
@@ -49,25 +49,25 @@ data class Roster(val id: Long, val name: String, val `class`: String, val level
 
 	data class DiffResult(val id: Long, val name: String?, val `class`: String?, val level: Long?, val exp: Long?, override val properties: Properties): PropertiesDiffAware {
 		override fun generateStatements(connection: Connection): List<PreparedStatement> {
-			val statements: List<PreparedStatement> = mutableListOf()
+			val statements: MutableList<PreparedStatement> = mutableListOf()
 
 			if (name != null) {
-				statements.addLast(updateStatementForName(connection))
+				statements.add(updateStatementForName(connection))
 			}
 
 			if (`class` != null) {
-				statements.addLast(updateStatementForClass(connection))
+				statements.add(updateStatementForClass(connection))
 			}
 
 			if (level != null) {
-				statements.addLast(updateStatementForLevel(connection))
+				statements.add(updateStatementForLevel(connection))
 			}
 
 			if (exp != null) {
-				statements.addLast(updateStatementForExp(connection))
+				statements.add(updateStatementForExp(connection))
 			}
 
-			getStatementsForProperties(connection).forEach { statements.addLast(it) }
+			getStatementsForProperties(connection).forEach { statements.add(it) }
 
 			return statements
 		}


### PR DESCRIPTION
Namely, I changed to `MutableList` instead of plain `List` when it's the return of `mutableListOf`.

It resolves the compile error in Kotlin `1.9.23`.
https://github.com/Attacktive/troubleshooter-editor-back-end/pull/133