### PR TITLE
refactor: enable batch inserts

### DIFF
--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/extension/Extensions.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/extension/Extensions.kt
@@ -16,7 +16,7 @@ inline infix fun <reified E: Enum<E>, V> ((E) -> V).findByOrNull(value: V): E? {
 	return enumValues<E>().firstOrNull { this(it) == value }
 }
 
-fun File.getJdbcUrl() = "jdbc:sqlite:${absolutePath}"
+fun File.getJdbcUrl() = "jdbc:sqlite:${absolutePath}?rewriteBatchedInserts=true"
 
 fun <I, T: Identifiable<I>> Collection<T>.findById(id: I): T? = asSequence().find { it.id == id }
 


### PR DESCRIPTION
Resolves https://github.com/Attacktive/troubleshooter-editor-back-end/issues/142.

Needs testing, though, if it's actually working.
SQLite might not work with `rewriteBatchedInserts` or `rewriteBatchedStatements`.
