### PR TITLE
chore: use single-string dependency notation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,18 +29,18 @@ repositories {
 dependencies {
 	val exposedVersion = "0.61.0"
 
-	implementation("org.springframework.boot", "spring-boot-starter-web")
-	implementation("com.fasterxml.jackson.module", "jackson-module-kotlin")
-	implementation("org.jetbrains.kotlin", "kotlin-stdlib-jdk8")
-	implementation("org.xerial", "sqlite-jdbc")
-	implementation("org.jetbrains.exposed", "exposed-core", exposedVersion)
-	implementation("org.jetbrains.exposed", "exposed-jdbc", exposedVersion)
-	implementation("org.jetbrains.exposed", "exposed-dao", exposedVersion)
+	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+	implementation("org.xerial:sqlite-jdbc")
+	implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
+	implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
+	implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
 
-	annotationProcessor("org.springframework.boot", "spring-boot-configuration-processor")
+	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 
 	testImplementation(kotlin("test"))
-	testImplementation("org.springframework.boot", "spring-boot-starter-test") {
+	testImplementation("org.springframework.boot:spring-boot-starter-test") {
 		exclude(module = "junit")
 		exclude(module = "junit-vintage-engine")
 		exclude(module = "mockito-core")


### PR DESCRIPTION
## Why

Dependabot has never once bumped Exposed, while `kotlinPluginVersion` and the Spring Boot plugin get bumped regularly. That asymmetry isn't about the `exposedVersion` variable — it's the notation.

Dependabot's Gradle parser matches dependencies with this regex ([`file_parser.rb`](https://github.com/dependabot/dependabot-core/blob/main/gradle/lib/dependabot/gradle/file_parser.rb)):

```ruby
PART     = %r{[^\s,@'":/\\]+}
VSN_PART = %r{[^\s,'":/\\]+}
DEPENDENCY_DECLARATION_REGEX = /(?:\(|\s)\s*['"](?<declaration>#{PART}:#{PART}:#{VSN_PART})['"]/o
```

It only matches `group:artifact:version` **inside one quoted string**. `PART` excludes both `:` and `"`, so a match can never span across `", "` into the next argument — the positional form produced no dependency and no error. The plugins block goes through a separate parse path, which is why plugin bumps kept working.

The variable itself was never the problem: the property finder has no block-scope awareness, so `val exposedVersion` inside `dependencies { }` resolves fine once `$exposedVersion` is inside the coordinate string.

## What

Every declaration in the block moved to the single-string overload, for consistency. **No version changes** — Exposed stays at `0.61.0`.

## Verification

`./gradlew dependencies --configuration testRuntimeClasspath` before and after the change: byte-identical output. Exposed still resolves to `0.61.0`.

Heads-up: Dependabot can now see Exposed, so expect a PR proposing a sizable upgrade from 0.61.0. That's a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)