### PR TITLE
chore: drop the unused exposed-dao dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
 	implementation("org.xerial:sqlite-jdbc")
 	implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
 	implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
-	implementation("org.jetbrains.exposed:exposed-dao:$exposedVersion")
 
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 


### PR DESCRIPTION
Follow-up to #300 (Exposed 0.61.0 → 1.3.1).

While auditing our API surface against JetBrains' [0.61.0 → 1.0.0 migration guide](https://www.jetbrains.com/help/exposed/migration-guide-1-0-0.html) to confirm the imports-only migration was actually complete, one thing stood out: **`exposed-dao` is declared but never used.**

A case-insensitive search for `dao` across `src/` returns zero hits — no `IntEntity`, `LongEntity`, `EntityClass`, `IdTable`, or `EntityID`. Every table is a plain `org.jetbrains.exposed.v1.core.Table` with a hand-declared `override val primaryKey = PrimaryKey(...)`. `exposed-dao` is the module carrying the DAO/entity API we don't use, so it's dead weight on the classpath and a third Exposed artifact for Dependabot to keep bumping forever.

`exposed-core` and `exposed-jdbc` stay — both are genuinely used.

## Verification

- `./gradlew compileKotlin compileTestKotlin` — clean, so nothing relied on it transitively.
- `./gradlew clean test jacocoTestReport` — 2/2 pass. These are the real signal: `SqliteServiceTest` drives `SqliteUseCase` → `SqliteService` → the Exposed-backed repositories, exercising `select`/`insert`/`update`/`deleteWhere`/joins/`transaction` against the real `game.sav` fixture and asserting on read-back values.
- Resolved `runtimeClasspath` diff shows **only** `exposed-dao` removed; its transitives (`exposed-jdbc`, `exposed-core`, `kotlin-stdlib`) are all still resolved via the direct declarations.

## Not included

The audit also surfaced a pre-existing issue, unrelated to the upgrade and left for a separate discussion: `Database.connect(url)` is called per repository method (7 sites) with the result discarded, relying on Exposed's process-wide default database while the services are Spring singletons — so concurrent requests on different `.sav` files can race onto each other's database. Present since 0.61.0 and unchanged by 1.3.1; the single-threaded tests wouldn't catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)