### PR TITLE
refactor: untangle the type arguments of `getDiffResults`

### DIFF
--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/common/extension/Extensions.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/common/extension/Extensions.kt
@@ -2,7 +2,6 @@ package com.github.attacktive.troubleshootereditor.common.extension
 
 import kotlin.reflect.full.companionObject
 import com.github.attacktive.troubleshootereditor.ingamedata.common.Diffable
-import com.github.attacktive.troubleshootereditor.ingamedata.common.IDiffResult
 import com.github.attacktive.troubleshootereditor.ingamedata.common.Identifiable
 import com.github.attacktive.troubleshootereditor.ingamedata.common.Properties
 import com.github.attacktive.troubleshootereditor.ingamedata.common.Property
@@ -17,7 +16,7 @@ inline infix fun <reified E: Enum<E>, V> ((E) -> V).findByOrNull(value: V): E? {
 
 fun <I, T: Identifiable<I>> Collection<T>.findById(id: I): T? = asSequence().find { it.id == id }
 
-fun <I, T: Diffable<T, I, D>, D: IDiffResult<I>> Collection<T>.getDiffResults(those: Collection<T>): List<D> {
+fun <I, T, D> Collection<T>.getDiffResults(those: Collection<T>): List<D> where T: Identifiable<I>, T: Diffable<T, D> {
 	return asSequence()
 		.mapNotNull { oldItem ->
 			val newItem = those.findById(oldItem.id)

--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/ingamedata/common/Diffable.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/ingamedata/common/Diffable.kt
@@ -1,5 +1,5 @@
 package com.github.attacktive.troubleshootereditor.ingamedata.common
 
-interface Diffable<T, I, D>: Identifiable<I> {
+interface Diffable<T, D> {
 	fun diff(that: T): D
 }

--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/ingamedata/item/domain/Item.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/ingamedata/item/domain/Item.kt
@@ -3,6 +3,7 @@ package com.github.attacktive.troubleshootereditor.ingamedata.item.domain
 import com.fasterxml.jackson.annotation.JsonGetter
 import com.github.attacktive.troubleshootereditor.ingamedata.common.Diffable
 import com.github.attacktive.troubleshootereditor.ingamedata.common.IDiffResult
+import com.github.attacktive.troubleshootereditor.ingamedata.common.Identifiable
 import com.github.attacktive.troubleshootereditor.ingamedata.common.Properties
 import com.github.attacktive.troubleshootereditor.ingamedata.item.adapter.outbound.table.ItemProperties
 import org.jetbrains.exposed.v1.core.and
@@ -11,7 +12,7 @@ import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.update
 
-data class Item(override val id: Long, val type: String, val count: Long, val status: String, val properties: Properties, var equipmentPosition: EquipmentPosition? = null): Diffable<Item, Long, Item.DiffResult> {
+data class Item(override val id: Long, val type: String, val count: Long, val status: String, val properties: Properties, var equipmentPosition: EquipmentPosition? = null): Identifiable<Long>, Diffable<Item, Item.DiffResult> {
 	constructor(id: Long, type: String, count: Long, status: String, properties: Map<String, String>, equipmentPosition: EquipmentPosition? = null): this(id, type, count, status, Properties(properties), equipmentPosition)
 
 	override fun diff(that: Item): DiffResult {

--- a/src/main/kotlin/com/github/attacktive/troubleshootereditor/ingamedata/roster/domain/Roster.kt
+++ b/src/main/kotlin/com/github/attacktive/troubleshootereditor/ingamedata/roster/domain/Roster.kt
@@ -2,6 +2,7 @@ package com.github.attacktive.troubleshootereditor.ingamedata.roster.domain
 
 import com.github.attacktive.troubleshootereditor.ingamedata.common.Diffable
 import com.github.attacktive.troubleshootereditor.ingamedata.common.IDiffResult
+import com.github.attacktive.troubleshootereditor.ingamedata.common.Identifiable
 import com.github.attacktive.troubleshootereditor.ingamedata.common.Properties
 import com.github.attacktive.troubleshootereditor.ingamedata.roster.adapter.outbound.table.RosterProperties
 import org.jetbrains.exposed.v1.core.and
@@ -10,7 +11,7 @@ import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.update
 
-data class Roster(override val id: Long, val name: String, val `class`: String, val level: Long, val exp: Long, val properties: Properties): Diffable<Roster, Long, Roster.DiffResult> {
+data class Roster(override val id: Long, val name: String, val `class`: String, val level: Long, val exp: Long, val properties: Properties): Identifiable<Long>, Diffable<Roster, Roster.DiffResult> {
 	override fun diff(that: Roster): DiffResult {
 		val name = that.name.takeUnless { name == that.name }
 		val `class` = that.`class`.takeUnless { `class` == that.`class` }


### PR DESCRIPTION
Closes #158.

## Before

```kotlin
interface Diffable<T, I, D>: Identifiable<I> {
	fun diff(that: T): D
}

fun <I, T: Diffable<T, I, D>, D: IDiffResult<I>> Collection<T>.getDiffResults(those: Collection<T>): List<D>
```

Three things were tangled here:

- **`T` meant two different things.** `Identifiable<T>` and `IDiffResult<T>` use `T` for the *id* type. `Diffable<T, I, D>` used `T` for the *self* type and renamed the id to `I` — so `Diffable<T, I, D>: Identifiable<I>` rebound `T` as it passed through the supertype clause.
- **`Diffable` extended `Identifiable` without needing to.** Diffing does not require identity. Diffing a *collection* does, because that is what pairs old with new. `I` was threaded through `Diffable` only to satisfy a caller.
- **`D: IDiffResult<I>` was a bound the function never used.** The body only calls `findById` (needs `Identifiable`) and `diff` (needs `Diffable`); `D` is only returned, never touched.

## After

```kotlin
interface Diffable<T, D> {
	fun diff(that: T): D
}

fun <I, T, D> Collection<T>.getDiffResults(those: Collection<T>): List<D> where T: Identifiable<I>, T: Diffable<T, D>
```

`Diffable` loses a type argument and says only what its name claims. The identity requirement sits on the one function that needs it. `Extensions.kt` no longer imports `IDiffResult`.

Dropping the `IDiffResult` bound loosens nothing in practice: a diff result still has to implement `IDiffResult` to reach `applyPropertyChanges`, which is where the constraint is actually enforced.

`Item` and `Roster` each declare `Identifiable<Long>` explicitly now — the whole cost of the change.

## Deliberately not done

Renaming the id parameter of `Identifiable<T>`/`IDiffResult<T>` to match. With `Diffable` no longer extending `Identifiable`, the two never meet in a declaration, and `T` is the conventional default for a single type parameter. `I` would also collide with the `I` prefix in `IDiffResult`.

## Verification

- `./gradlew compileKotlin compileTestKotlin` — clean
- `./gradlew clean test` — green
- Both call sites (`ItemService.kt:88`, `RosterService.kt:51`) are unchanged and still infer without explicit type arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
